### PR TITLE
Fixed logo when switching to mobile view

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -22,6 +22,14 @@
       .logo {
         width: 1.4375rem;
       }
+
+      .logoSmall {
+        display: block;
+      }
+
+      .logoLarge {
+        display: none;
+      }
     }
   }
 }
@@ -54,6 +62,14 @@
   @media (min-width: breakpoint.$desktop) {
     margin: space.$s0 space.$s4;
   }
+}
+
+.logoLarge {
+  display: block;
+}
+
+.logoSmall {
+  display: none;
 }
 
 .menuButton {

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -20,6 +20,7 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   return (
     <div
       className={classNames(
@@ -36,13 +37,14 @@ export function SidebarNavigation() {
         <header className={styles.header}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
+            src="/icons/logo-large.svg"
             alt="logo"
-            className={styles.logo}
+            className={classNames(styles.logo, styles.logoLarge)}
+          />
+          <img
+            src="/icons/logo-small.svg"
+            alt="logo"
+            className={classNames(styles.logo, styles.logoSmall)}
           />
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}


### PR DESCRIPTION
### Summary 

Split the small and large logos into their own img tags. Also removed the isCollapsed src. Added .logoSmall and .logoLarge styling to the sidebar-nav.module

![2024-02-23 23 48 34](https://github.com/profydev/prolog-app-Sigouin/assets/104263329/3c2676e4-0164-4fe7-ab02-10a201b3140b)
