### PR TITLE
Support button now working as intended

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -36,7 +36,7 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get("nav").find("a").should("have.length", 6).eq(1).click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -80,7 +80,7 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get("nav").find("a").should("have.length", 6);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -21,6 +21,9 @@ export function SidebarNavigation() {
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
 
+  const recipientEmail = "support@prolog-app.com";
+  const mailtoLink = `mailto:${recipientEmail}?subject=Support%20Request:`;
+
   return (
     <div
       className={classNames(
@@ -41,6 +44,7 @@ export function SidebarNavigation() {
             alt="logo"
             className={classNames(styles.logo, styles.logoLarge)}
           />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src="/icons/logo-small.svg"
             alt="logo"
@@ -81,11 +85,12 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              href={mailtoLink}
+              isActive
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Clicking support now opens the user's email app. The email has the recipient set to "support@prolog-app.com" and  a pre-filled subject line set to "Support Request:"