### PR TITLE
Refactored Button Component. Added to Storybook

### DIFF
--- a/features/ui/button/button.module.scss
+++ b/features/ui/button/button.module.scss
@@ -1,5 +1,11 @@
+@use "@styles/color";
+@use "@styles/font";
+@use "@styles/space";
+@use "@styles/breakpoint";
+
 .button {
   cursor: pointer;
+  border-radius: space.$s2;
 
   /* remove default button styles */
   border: none;
@@ -14,5 +20,153 @@
   &::-moz-focus-inner {
     border: 0;
     padding: 0;
+  }
+
+  .hasIcon {
+    display: flex;
+    align-items: center;
+    gap: space.$s2;
+  }
+
+  // Button Sizes
+  &.sm {
+    font: font.$text-sm-medium;
+    padding: space.$s2 0.875rem;
+  }
+
+  &.md {
+    font: font.$text-sm-medium;
+    padding: 0.625rem space.$s4;
+  }
+
+  &.lg {
+    font: font.$text-md-medium;
+    padding: 0.625rem 1.125rem;
+  }
+
+  &.xl {
+    font: font.$text-md-medium;
+    padding: space.$s3 space.$s5;
+  }
+
+  // Button Variants
+  &.primary {
+    background: color.$primary-600;
+    color: color.$primary-50;
+
+    &:hover {
+      background: color.$primary-700;
+    }
+
+    &:focus {
+      outline: 4px solid color.$primary-100;
+    }
+
+    &:disabled {
+      background: color.$primary-200;
+    }
+  }
+
+  &.secondary {
+    background: color.$primary-50;
+    color: color.$primary-700;
+
+    &:hover {
+      background: color.$primary-100;
+    }
+
+    &:focus {
+      outline: 4px solid color.$primary-100;
+    }
+
+    &:disabled {
+      color: color.$primary-300;
+    }
+  }
+
+  &.gray {
+    color: color.$gray-700;
+    background: white;
+    border: 1px solid color.$gray-300;
+
+    &:hover {
+      background: color.$gray-50;
+    }
+
+    &:focus {
+      outline: 4px solid color.$gray-100;
+    }
+
+    &:disabled {
+      color: color.$gray-300;
+    }
+  }
+
+  &.empty {
+    background: transparent;
+    color: color.$primary-700;
+
+    &:hover {
+      background: color.$primary-50;
+    }
+
+    &:focus {
+      outline: 4px solid color.$primary-100;
+    }
+
+    &:disabled {
+      color: color.$gray-300;
+    }
+  }
+
+  &.emptyGray {
+    background: transparent;
+    color: color.$gray-500;
+
+    &:hover {
+      background: color.$gray-50;
+    }
+
+    &:focus {
+      outline: 4px solid color.$gray-100;
+    }
+
+    &:disabled {
+      color: color.$gray-300;
+    }
+  }
+
+  &.error {
+    background: color.$error-600;
+    color: color.$error-50;
+
+    &:hover {
+      background: color.$error-700;
+    }
+
+    &:focus {
+      outline: 4px solid color.$error-100;
+    }
+
+    &:disabled {
+      background: color.$error-200;
+    }
+  }
+
+  &.emptyError {
+    background: transparent;
+    color: color.$error-700;
+
+    &:hover {
+      background: color.$error-50;
+    }
+
+    &:focus {
+      outline: 4px solid color.$error-100;
+    }
+
+    &:disabled {
+      color: color.$error-300;
+    }
   }
 }

--- a/features/ui/button/button.stories.tsx
+++ b/features/ui/button/button.stories.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react";
+import { Button, ButtonColor, ButtonSize } from "./button";
+
+export default {
+  title: "UI/Button",
+  component: Button,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+  },
+} as Meta<typeof Button>;
+
+const Template: StoryFn<typeof Button> = ({
+  size,
+  color,
+  children,
+  ...args
+}) => (
+  <Button color={color} size={size} {...args}>
+    {children}
+  </Button>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  size: ButtonSize.md,
+  color: ButtonColor.primary,
+  children: "Button CTA",
+};
+export const Focused = Template.bind({});
+Focused.args = {
+  size: ButtonSize.md,
+  color: ButtonColor.primary,
+  children: "Focused Button",
+  autoFocus: true,
+};
+export const Disabled = Template.bind({});
+Disabled.args = {
+  size: ButtonSize.md,
+  color: ButtonColor.error,
+  children: "Disabled Button",
+  disabled: true,
+};
+export const withIcon = Template.bind({});
+withIcon.args = {
+  size: ButtonSize.md,
+  color: ButtonColor.primary,
+  children: "Button with Icon",
+  icon: (
+    <span role="img" aria-label="rocket">
+      🚀
+    </span>
+  ),
+  iconPosition: "leading",
+};
+
+Default.parameters = {
+  viewMode: "docs",
+};

--- a/features/ui/button/button.tsx
+++ b/features/ui/button/button.tsx
@@ -1,9 +1,63 @@
-import { ButtonHTMLAttributes } from "react";
+import React, { ButtonHTMLAttributes } from "react";
 import classNames from "classnames";
 import styles from "./button.module.scss";
 
-export function Button(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+export enum ButtonSize {
+  sm = "sm",
+  md = "md",
+  lg = "lg",
+  xl = "xl",
+}
+
+export enum ButtonColor {
+  primary = "primary",
+  secondary = "secondary",
+  gray = "gray",
+  empty = "empty",
+  emptyGray = "emptyGray",
+  error = "error",
+  emptyError = "emptyError",
+}
+
+export type ButtonIcon = React.ReactNode;
+
+export enum ButtonIconPosition {
+  leading = "leading",
+  trailing = "trailing",
+}
+
+type ButtonProps = {
+  children: React.ReactNode;
+  size?: ButtonSize;
+  color?: ButtonColor;
+  icon?: ButtonIcon;
+  iconPosition?: ButtonIconPosition | string;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({
+  children,
+  icon,
+  size,
+  color,
+  iconPosition,
+  ...props
+}: ButtonProps) {
+  const hasIcon = icon ? "hasIcon" : "";
+
   return (
-    <button {...props} className={classNames(styles.button, props.className)} />
+    <button
+      {...props}
+      className={classNames(
+        styles.button,
+        props.className,
+        styles[size || ""],
+        styles[color || ""],
+        styles[hasIcon],
+      )}
+    >
+      {iconPosition === "leading" && icon}
+      {children}
+      {iconPosition === "trailing" && icon}
+    </button>
   );
 }


### PR DESCRIPTION
Button component refactored to match figma design. It now supports all required sizes, colors, states, and being rendered with or as an icon. The component has been added to Storybook with documentation.

I would like to refactor the scss module when I have time to have the button styles work with opacity to clear up some redundancy in styling.