### PR TITLE
View issues link correctly directs user

### DIFF
--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -33,9 +33,6 @@ describe("Project List", () => {
           cy.wrap($el).contains(mockProjects[index].numIssues);
           cy.wrap($el).contains(mockProjects[index].numEvents24h);
           cy.wrap($el).contains(statusNames[index]);
-          cy.wrap($el)
-            .find("a")
-            .should("have.attr", "href", "/dashboard/issues");
         });
     });
   });
@@ -75,5 +72,29 @@ describe("Error Screen Test", () => {
       .click();
 
     cy.get("[data-testid='project-list']").should("be.visible");
+  });
+});
+
+describe("Project Card View Issues Test", () => {
+  // const projectNames = ["Frontend - Web", "Backend", "ML Service"];
+
+  beforeEach(() => {
+    // Visit the page containing the project cards
+    cy.visit("http://localhost:3000/dashboard");
+  });
+
+  it("verifies the href attribute of View issues links for each project", () => {
+    // Iterate over each project name
+    cy.get("main")
+      .find("a")
+      .each((el, index) => {
+        cy.wrap(el).should(
+          "have.attr",
+          "href",
+          `/dashboard/issues?project=${encodeURIComponent(
+            mockProjects[index].name,
+          )}`,
+        );
+      });
   });
 });

--- a/cypress/fixtures/projects.json
+++ b/cypress/fixtures/projects.json
@@ -4,7 +4,7 @@
     "numIssues": 73,
     "numEvents24h": 7,
     "status": "error",
-    "name": "Frontend - Web Test",
+    "name": "Frontend - Web",
     "language": "react"
   },
   {

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -56,7 +56,10 @@ export function ProjectCard({ project }: ProjectCardProps) {
         </div>
       </div>
       <div className={styles.bottomContainer}>
-        <Link href={Routes.issues} className={styles.viewIssuesAnchor}>
+        <Link
+          href={`${Routes.issues}?project=${project.name}`}
+          className={styles.viewIssuesAnchor}
+        >
           View issues
         </Link>
       </div>


### PR DESCRIPTION
View issues link in the project card now correctly directs to the issues page with pre-selected project filters. 

Cypress tests written.